### PR TITLE
Fixed init problem in Chrome (not tested on Safari)

### DIFF
--- a/docs/plugins/haveibeenpwned/manifest.json
+++ b/docs/plugins/haveibeenpwned/manifest.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/leolivier"
   },
   "resources": {
-    "js": "na+696slok4iEscUEExyD2dF6bwT1AlmtiIogdAda9xZiBGiSNM4u43Q9oaBbnT+U1Kgoumgh0lHbnb+Hy5YtSFUTCi5M3+DKgaGVIQD0DivXqojGQF+aPKRnBv5tYu4QlGCXVVr3rXf65FHghfTXTrN0vSXM/PcysZkkrgaY6qxUZsROfnLX4EeX9JKdHcqRA3JpQI3ptBiYPL6zzJuQZcD18IMuULvs07f3QpP5IiTsgOWftBEQ20RPr3gqAjd6aAhKYGiNqBaJ7wR8MCKqNiJ4yPv6fPpNdimbh/mP3LY69CFaGvi9ZyABcP7I5zenw1ZScQsYfC+Qix25LZqBw=="
+    "js": "BeXlCVvW20aFD4PXy65b/sMxTl44rMy6yvFgTGIHJGlnLxIyQIvp4wPcDyf6sSXZqn5IthrxSDvRvsAW/gOcbeOAt/cwsafazJXU1El1xjKJ5FGcE6oJLZfcBYDSoAk5+OBQi1Casyw5F1PflBxtk4J64ASADnNNZbEi+kpnZcIho6e//qwfXMpqMftCZVqWgqVQX0N9OFa7qWxLv2x4acLx2B7cHu7/No97ChjwNNh8vqjo2BQG40rjiCtx0P6lh2r54K5c1QC3k15OJM2atSA+mG6d3HhHqhJMhjOCp3BwwyVfJ1jZ6/xg6GBDTaDmaIuegAfXd+gpZ+8DG5iPPg=="
   },
   "url": "https://plugins.keeweb.info/plugins/haveibeenpwned",
   "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp9Cay/z7whBsHcf9klDjlA4qylWT7a/igTJ2nvUq2XuQrx98PTOexzzzg5oflk8nPEaMIsaFIf90V/rvQjJ1z9DR4zuQKDb4/GZVzxoylECAwNk80LvSPc1G0+6mwXIFp48wc6Advd4iYQCMkzWDCJXEm/1E+q85ty+H6EaLleKcJI0vlW96bbA9vFCmOsM5PYZfoGnVFRBLVthyUcGneilMvsxu5J7DKggQKPs04/WQZ5oHbUG83mxkxTdYDC3glpvV4BiaAD6z+2usO+fA97bXb+rY3O2iHJgWsa7jH0ybO0Nif6txE4d2+LJOLmfoImv7kdyu/eN3A78KejCOhwIDAQAB",


### PR DESCRIPTION
Thanks to your answer @antelle , I managed  to fix the issue in Chrome.
I can't test it in Safari, so please do it if you can... (it's easy if you try with user name = foo and password = 12345)

FYI, next steps for me are:
- prevent the user to change the user name or the password if they have been pwned and the "blockXXX" checkbox are ticked
- Enable checking the whole list of user names and passwords in a file, looking for pawned items.