### PR TITLE
Fix KeeWebHTTP plugin compatibility with latest Firefox versions

### DIFF
--- a/docs/plugins/keewebhttp/manifest.json
+++ b/docs/plugins/keewebhttp/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "manifestVersion": "0.1.0",
   "versionMin": "1.11.0",
   "name": "keewebhttp",

--- a/docs/plugins/keewebhttp/plugin.js
+++ b/docs/plugins/keewebhttp/plugin.js
@@ -66,7 +66,7 @@ function run() {
         server = http.createServer((req, res) => {
             const origin = req.headers.origin;
             const referer = req.headers.referrer || req.headers.referer;
-            if (req.method !== 'POST' || referer || origin &&
+            if (req.method !== 'POST' || referer || origin === null || origin &&
                 !origin.startsWith('chrome-extension://') && !origin.startsWith('safari-extension://')
             ) {
                 if (DebugMode) {


### PR DESCRIPTION
Hello.

I use KeeWeb v1.16.5 with KeeWebHTTP plugin v1.0.1.
My browser is Mozilla FIrefox Nightly (85.0b3) with KeePass HTTP extension v1.0.11.

Until recent update everything worked perfectly, but now KeePass HTTP extension cannot connect to KeeWeb.

I've checked requests which are received by KeeWebHTTP plugin:
```
Request dropped POST /

accept: "*/*"
accept-encoding: "gzip, deflate"
accept-language: "ru,en-US;q=0.7,en;q=0.3"
connection: "keep-alive"
content-length: "54"
content-type: "application/json"
cookie: "..."
host: "localhost:19455"
origin: "null"
user-agent: "Mozilla/5.0 (X11; Linux x86_64; rv:85.0) Gecko/20100101 Firefox/85.0"
```

`Origin` header is `null`, but according to plugin source code it should be non-empty and have certain prefix:
https://github.com/keeweb/keeweb-plugins/blob/682ee7c8e56dae9b11042fa6a4c08e49edf5b0a0/docs/plugins/keewebhttp/plugin.js#L69-L70

It looks like passing Origin header from extension pages (both settings and pop-ups) was disabled in nightly Firefox versions.

I found this issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1405971
According to comments, Origin header in requests made by browser extensions can expose extension UUID to sites, and this one of fingerprinting vector. The desired solution was to set Origin to null, and it looks like they finally did that.

In this PR I've removed Origin header check because it will ruin extension work after the same change will be made on stable Firefox version.